### PR TITLE
don't require pre-entering values into redis to edit config

### DIFF
--- a/donormotor/templates/admin/premium_config.html
+++ b/donormotor/templates/admin/premium_config.html
@@ -38,7 +38,7 @@
         <form method="post">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
             <label for="ack_email">Acknowlegement Email:</label></br>
-	    <input type=email id="ack_email" name="ack_email" value="{{ ack_email }}" /><br>
+	    <input type="email" id="ack_email" name="ack_email" value="{{ ack_email }}" /><br>
             <div class="btn-group btn-group-sm">
                 <button name="update_ack_email" type="submit" class="btn btn-sm">Update</button>
                 <button name="default_ack_email" type="submit" class="btn btn-sm btn-danger">Reset</button>

--- a/donormotor/templates/admin/premium_config.html
+++ b/donormotor/templates/admin/premium_config.html
@@ -38,7 +38,7 @@
         <form method="post">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
             <label for="ack_email">Acknowlegement Email:</label></br>
-            <textarea id="ack_email" name="ack_email">{{ ack_email }}</textarea> <br>
+	    <input type=email id="ack_email" name="ack_email" value="{{ ack_email }}" /><br>
             <div class="btn-group btn-group-sm">
                 <button name="update_ack_email" type="submit" class="btn btn-sm">Update</button>
                 <button name="default_ack_email" type="submit" class="btn btn-sm btn-danger">Reset</button>


### PR DESCRIPTION
this is a pretty simple change. ideally "default_premiums" would be moved into config[], but that may just result in more confusion. This interface is really a stopgap for #30 anyway.